### PR TITLE
Add hack the north 2026

### DIFF
--- a/app/[slug]/mdx/hackathons.mdx
+++ b/app/[slug]/mdx/hackathons.mdx
@@ -26,6 +26,16 @@ export {
 
     <div className='md:w-[90%] w-full mx-auto space-y-10'>
 
+        {/* hack the north 2026 */}
+        <section className='flex flex-col text-left border-b border-white/20 pb-8'>
+            <span className='text-lightBeige/95 text-xl font-medium'>hack the north</span>
+            <span className='text-lighterBeige/80 text-sm'>september 18–20, 2026 · waterloo, ontario</span>
+            <div className='text-lighterBeige font-inter font-extralight text-[1rem] mt-2'>coming soon — canada&apos;s biggest hackathon at the university of waterloo.</div>
+            <div className='mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm'>
+                <a href="https://hackthenorth.com" target="_blank" rel="noopener noreferrer" className='a'>hack the north site</a>
+            </div>
+        </section>
+
         {/* summerhacks 2026 */}
         <section className='flex flex-col text-left border-b border-white/20 pb-8'>
             <span className='text-lightBeige/95 text-xl font-medium'>summerhacks</span>

--- a/app/data/hackathons.ts
+++ b/app/data/hackathons.ts
@@ -6,6 +6,7 @@ export const hackathonEntries = [
   { role: "hacker" },
   { role: "hacker" },
   { role: "hacker" },
+  { role: "hacker" },
   { role: "judge" },
   { role: "hacker" },
   { role: "hacker", awards: 1 },


### PR DESCRIPTION
## Summary
- Add hack the north (september 18–20, 2026 · waterloo) to the hackathons list
- Update the hackathon count tally

## Test plan
- [ ] Open `/hackathons` and confirm the new entry is at the top
- [ ] Confirm the total hackathon count increased by one


Made with [Cursor](https://cursor.com)